### PR TITLE
add end tag marker for img in _footer

### DIFF
--- a/_footer.html
+++ b/_footer.html
@@ -1,6 +1,6 @@
 <p>
   <a href="https://bren.ucsb.edu/">
-    <img src="img/bren_white_logo.png" alt="Bren School logo" width="350">
+    <img src="img/bren_white_logo.png" alt="Bren School logo" width="350" />
   </a>
 </p>
 


### PR DESCRIPTION
This should fix the "Opening and ending tag mismatch" error reported here: https://github.com/rstudio/distill/issues/354

LMK if this does the trick (it's certainly possible there are other issues w/ images referenced in headers/footers as that's not something I can recall trying during development.